### PR TITLE
添加文章缩略图功能

### DIFF
--- a/.vitepress/theme/components/Posts-List.vue
+++ b/.vitepress/theme/components/Posts-List.vue
@@ -206,7 +206,7 @@ const finalPosts = computed(() => {
         .cover-container {
           flex: none;
           width: 100%;
-          height: 160px;
+          height: 240px;
           margin-left: 0;
         }
       }

--- a/.vitepress/theme/components/Posts-List.vue
+++ b/.vitepress/theme/components/Posts-List.vue
@@ -2,29 +2,38 @@
   <div class="container posts-content">
     <TransitionGroup class="posts-list" name="list" tag="div">
       <article class="post" v-for="post in postsList" :key="post.href">
-        <p v-if="post.cover"> {{ post.cover }} </p>
         <span v-if="post.pinned" class="pinned"></span>
         <header class="post-header">
-          <div class="title">
-            <div class="title-dot"></div>
-            <h1 class="name">
-              <a :href="base + post.href">{{ post.title }}</a>
-            </h1>
+          <div v-if="post.cover" class="cover-container">
+            <img 
+              :src="post.cover" 
+              class="cover-image" 
+              :alt="post.title + '-cover'"
+              loading="lazy"
+            >
           </div>
-          <div class="meta-info-bar">
-            <span class="iconfont icon-time time"></span>
-            <div class="time-info">
-              <time datetime="">{{ formatDate(post.create) }}</time>
+          <div class="header-content">
+            <div class="title">
+              <div class="title-dot" v-if="!post.cover"></div>
+              <h1 class="name">
+                <a :href="base + post.href">{{ post.title }}</a>
+              </h1>
             </div>
-            <div class="wordcount seperator">约{{ post.wordCount }}字</div>
+            <div class="meta-info-bar">
+              <span class="iconfont icon-time time"></span>
+              <div class="time-info">
+                <time datetime="">{{ formatDate(post.create) }}</time>
+              </div>
+              <div class="wordcount seperator">约{{ post.wordCount }}字</div>
+            </div>
+            <ul class="tags">
+              <li v-for="tag in post.tags">
+                <a :href="`${base}tags/`" @click="state.currTag = tag"
+                  ><i class="iconfont icon-tag"></i> {{ tag }}</a
+                >
+              </li>
+            </ul>
           </div>
-          <ul class="tags">
-            <li v-for="tag in post.tags">
-              <a :href="`${base}tags/`" @click="state.currTag = tag"
-                ><i class="iconfont icon-tag"></i> {{ tag }}</a
-              >
-            </li>
-          </ul>
         </header>
         <div class="excerpt">
           <p>{{ post.excerpt }}</p>
@@ -123,7 +132,7 @@ const finalPosts = computed(() => {
 .posts-list {
   position: relative;
   overflow-wrap: break-word;
-
+  
   .post {
     display: flex;
     flex-direction: column;
@@ -148,6 +157,59 @@ const finalPosts = computed(() => {
       background: var(--icon-pinned) no-repeat;
       background-size: contain;
       box-shadow: 0 0 6px rgba(var(--blue-shadow-color), 0.65);
+    }
+
+    .post-header {
+      display: flex;
+      gap: 24px;
+      padding: 32px 40px 0;
+      position: relative;
+
+      .cover-container {
+        flex: 0 0 160px;
+        height: 120px;
+        border-radius: 12px;
+        overflow: hidden;
+        position: relative;
+        margin-left: -8px; 
+        align-self: flex-start; 
+        
+        .cover-image {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          transition: transform 0.3s ease;
+          
+          &:hover {
+            transform: scale(1.05);
+          }
+        }
+      }
+      .header-content {
+        flex: 1;
+        min-width: 0; 
+        
+        .title {
+          position: relative;
+          margin-bottom: 8px;
+
+        }
+      }
+    }
+
+    @media (max-width: 768px) {
+      .post-header {
+        flex-direction: column;
+        gap: 16px;
+        padding: 24px 20px 0;
+        
+        .cover-container {
+          flex: none;
+          width: 100%;
+          height: 160px;
+          margin-left: 0;
+        }
+      }
     }
   }
 }

--- a/.vitepress/theme/components/Posts-List.vue
+++ b/.vitepress/theme/components/Posts-List.vue
@@ -14,7 +14,7 @@
           </div>
           <div class="header-content">
             <div class="title">
-              <div class="title-dot" v-if="!post.cover"></div>
+              <div class="title-dot"></div>
               <h1 class="name">
                 <a :href="base + post.href">{{ post.title }}</a>
               </h1>
@@ -33,11 +33,11 @@
                 >
               </li>
             </ul>
+            <div class="excerpt">
+              <p>{{ post.excerpt }}</p>
+            </div>
           </div>
         </header>
-        <div class="excerpt">
-          <p>{{ post.excerpt }}</p>
-        </div>
       </article>
     </TransitionGroup>
     <span v-if="totalPage != 1" class="pagination">
@@ -163,36 +163,42 @@ const finalPosts = computed(() => {
       display: flex;
       gap: 24px;
       padding: 32px 40px 0;
+      flex-direction: row-reverse;
       position: relative;
+      align-items: stretch;
 
       .cover-container {
-        flex: 0 0 160px;
-        height: 120px;
+        flex: 0 0 180px;
+        height: 140px;
         border-radius: 12px;
         overflow: hidden;
         position: relative;
         margin-left: -8px; 
-        align-self: flex-start; 
-        
+        margin-bottom: 15px;
+        align-self: center; 
         .cover-image {
           width: 100%;
           height: 100%;
           object-fit: cover;
           transition: transform 0.3s ease;
-          
           &:hover {
             transform: scale(1.05);
           }
         }
       }
+
       .header-content {
         flex: 1;
         min-width: 0; 
-        
+        flex-direction: column;
         .title {
           position: relative;
           margin-bottom: 8px;
-
+        }
+        .excerpt {
+          flex: 1;
+          display: flex;
+          align-items: flex-end;
         }
       }
     }
@@ -301,10 +307,6 @@ const finalPosts = computed(() => {
       }
     }
   }
-}
-
-.excerpt {
-  padding: 0 40px;
 }
 
 .pagination {

--- a/.vitepress/theme/components/Posts-List.vue
+++ b/.vitepress/theme/components/Posts-List.vue
@@ -14,7 +14,7 @@
           </div>
           <div class="header-content">
             <div class="title">
-              <div class="title-dot"></div>
+              <div class="title-dot" v-if="!post.cover"></div>
               <h1 class="name">
                 <a :href="base + post.href">{{ post.title }}</a>
               </h1>
@@ -163,7 +163,7 @@ const finalPosts = computed(() => {
       display: flex;
       gap: 24px;
       padding: 32px 40px 0;
-      flex-direction: row-reverse;
+      // flex-direction: row-reverse;
       position: relative;
       align-items: stretch;
 

--- a/.vitepress/theme/components/Posts-List.vue
+++ b/.vitepress/theme/components/Posts-List.vue
@@ -2,6 +2,7 @@
   <div class="container posts-content">
     <TransitionGroup class="posts-list" name="list" tag="div">
       <article class="post" v-for="post in postsList" :key="post.href">
+        <p v-if="post.cover"> {{ post.cover }} </p>
         <span v-if="post.pinned" class="pinned"></span>
         <header class="post-header">
           <div class="title">

--- a/.vitepress/theme/utils/posts.data.d.ts
+++ b/.vitepress/theme/utils/posts.data.d.ts
@@ -9,5 +9,6 @@ export interface PostData {
   wordCount: number
   cover?: string
   excerpt: string
+  pinned?: boolean
 }
 export declare const data: PostData[]

--- a/posts/cover-test-norm.md
+++ b/posts/cover-test-norm.md
@@ -1,5 +1,5 @@
 ---
-title: Cover test
+title: Cover test 1
 
 date: 2025-5-11
 
@@ -7,7 +7,6 @@ tags: [image]
 
 cover: /wallpaper-2572384.webp
 ---
-
 This is a cover test post.
 
 ---

--- a/posts/cover-test-vert.md
+++ b/posts/cover-test-vert.md
@@ -1,7 +1,7 @@
 ---
-title: Cover test 1
+title: Cover test 3
 
-date: 2025-5-11
+date: 2025-5-9
 
 tags: [image]
 

--- a/posts/cover-test-vert.md
+++ b/posts/cover-test-vert.md
@@ -1,0 +1,12 @@
+---
+title: Cover test 1
+
+date: 2025-5-11
+
+tags: [image]
+
+cover: /wallpaper-2311325.webp
+---
+This is a cover test post.
+
+---

--- a/posts/cover-test-wide.md
+++ b/posts/cover-test-wide.md
@@ -1,0 +1,12 @@
+---
+title: Cover test 2
+
+date: 2025-5-11
+
+tags: [image]
+
+cover: /wallpaper-878514.webp
+---
+This is a cover test post.
+
+---

--- a/posts/cover-test-wide.md
+++ b/posts/cover-test-wide.md
@@ -1,7 +1,7 @@
 ---
 title: Cover test 2
 
-date: 2025-5-11
+date: 2025-5-10
 
 tags: [image]
 

--- a/posts/cover-test.md
+++ b/posts/cover-test.md
@@ -1,0 +1,13 @@
+---
+title: Cover test
+
+date: 2025-5-11
+
+tags: [image]
+
+cover: /wallpaper-2572384.webp
+---
+
+This is a cover test post.
+
+---


### PR DESCRIPTION
如 #36 所述，添加了类似于 hexo fluid 主题的文章缩略图（封面）功能

![image](https://github.com/user-attachments/assets/0d2c4e05-b0a5-429c-a6b9-8f067874717d)

可以通过在文章的 markdown 的 frontmatter 部分加入 `cover` 字段添加封面。

```yaml
title: Cover test 1
date: 2025-5-11
tags: [image]
cover: path_to_img
```

效果如下

![image](https://github.com/user-attachments/assets/dff0c8a7-225e-46f9-bbae-46d3a451d832)

移动端效果如下

![image](https://github.com/user-attachments/assets/57c7d053-18a8-4af7-a304-e8d02aa43f81)

为视觉效果，在有封面图时不显示 `title-dot`。
