### PR TITLE
RSS 订阅支持

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -4,7 +4,7 @@ import mdItCustomAttrs from 'markdown-it-custom-attrs'
 import { RSSOptions, RssPlugin } from 'vitepress-plugin-rss'
 
 // 访问 RSS 资源的 URL
-const baseUrl = 'http://127.0.0.1:8000'
+const baseUrl = 'https://vitepress-theme-bluearchive.vercel.app'
 const rssFilename = 'feed.rss'
 const RSS: RSSOptions = {
   title: "BSensei's 部落格",

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,5 +1,18 @@
 import { defineConfigWithTheme } from 'vitepress'
 import mdItCustomAttrs from 'markdown-it-custom-attrs'
+
+import { RSSOptions, RssPlugin } from 'vitepress-plugin-rss'
+
+// 访问 RSS 资源的 URL
+const baseUrl = 'http://127.0.0.1:8000'
+const rssFilename = 'feed.rss'
+const RSS: RSSOptions = {
+  title: "BSensei's 部落格",
+  baseUrl,
+  copyright: 'Copyright (c) 2025 Blue Archive',
+  filename: rssFilename
+}
+
 export interface ThemeConfig {
   //navBar
   menuList: { name: string; url: string }[]
@@ -9,7 +22,7 @@ export interface ThemeConfig {
   name: string
   welcomeText: string
   motto: string[]
-  social: { icon: string; url: string }[]
+  socialLinks: { icon: string; url: string }[]
 
   //spine
   spineVoiceLang: 'zh' | 'jp'
@@ -82,11 +95,12 @@ export default defineConfigWithTheme<ThemeConfig>({
     name: "Sensei's 部落格",
     welcomeText: 'Hello, VitePress',
     motto: ['和你的日常，就是奇迹', '何気ない日常で、ほんの少しの奇跡を見つける物語。'],
-    social: [
+    socialLinks: [
       { icon: 'github', url: 'https://github.com/' },
       { icon: 'bilibili', url: 'https://www.bilibili.com/' },
       { icon: 'qq', url: 'https://im.qq.com/index/' },
       { icon: 'wechat', url: 'https://weixin.qq.com/' },
+      { icon: 'continue', url: `${baseUrl}/${rssFilename}` },
     ],
 
     //spine语音配置，可选zh/jp
@@ -117,4 +131,7 @@ export default defineConfigWithTheme<ThemeConfig>({
       })
     },
   },
+  vite: {
+    plugins: [RssPlugin(RSS)]
+  }
 })

--- a/.vitepress/theme/components/Welcome-Box.vue
+++ b/.vitepress/theme/components/Welcome-Box.vue
@@ -40,7 +40,7 @@ const themeConfig = useData().theme.value
 const name = themeConfig.name
 const welcomeText = themeConfig.welcomeText
 const motto = themeConfig.motto
-const social = themeConfig.social
+const social = themeConfig.socialLinks
 
 const multiple = 30
 const welcomeBoxRef = ref<HTMLElement | null>(null)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "markdown-it-custom-attrs": "^1.0.2",
     "md5": "^2.3.0",
     "minisearch": "^7.1.1",
-    "normalize.css": "^8.0.1"
+    "normalize.css": "^8.0.1",
+    "vitepress-plugin-rss": "^0.3.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
+      vitepress-plugin-rss:
+        specifier: ^0.3.1
+        version: 0.3.1(vitepress@1.6.3(@algolia/client-search@5.14.2)(@types/node@22.13.1)(less@4.2.2)(markdown-it-mathjax3@4.3.2)(postcss@8.4.49)(search-insights@2.14.0))
     devDependencies:
       '@types/animejs':
         specifier: ^3.1.12
@@ -334,55 +337,46 @@ packages:
     resolution: {integrity: sha512-pWJsfQjNWNGsoCq53KjMtwdJDmh/6NubwQcz52aEwLEuvx08bzcy6tOUuawAOncPnxz/3siRtd8hiQ32G1y8VA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.21.0':
     resolution: {integrity: sha512-efRIANsz3UHZrnZXuEvxS9LoCOWMGD1rweciD6uJQIx2myN3a8Im1FafZBzh7zk1RJ6oKcR16dU3UPldaKd83w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.21.0':
     resolution: {integrity: sha512-ZrPhydkTVhyeGTW94WJ8pnl1uroqVHM3j3hjdquwAcWnmivjAwOYjTEAuEDeJvGX7xv3Z9GAvrBkEzCgHq9U1w==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.21.0':
     resolution: {integrity: sha512-cfaupqd+UEFeURmqNP2eEvXqgbSox/LHOyN9/d2pSdV8xTrjdg3NgOFJCtc1vQ/jEke1qD0IejbBfxleBPHnPw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.21.0':
     resolution: {integrity: sha512-ZKPan1/RvAhrUylwBXC9t7B2hXdpb/ufeu22pG2psV7RN8roOfGurEghw1ySmX/CmDDHNTDDjY3lo9hRlgtaHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.21.0':
     resolution: {integrity: sha512-H1eRaCwd5E8eS8leiS+o/NqMdljkcb1d6r2h4fKSsCXQilLKArq6WS7XBLDu80Yz+nMqHVFDquwcVrQmGr28rg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.21.0':
     resolution: {integrity: sha512-zJ4hA+3b5tu8u7L58CCSI0A9N1vkfwPhWd/puGXwtZlsB5bTkwDNW/+JCU84+3QYmKpLi+XvHdmrlwUwDA6kqw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.21.0':
     resolution: {integrity: sha512-e2hrvElFIh6kW/UNBQK/kzqMNY5mO+67YtEh9OA65RM5IJXYTWiXjX6fjIiPaqOkBthYF1EqgiZ6OXKcQsM0hg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.21.0':
     resolution: {integrity: sha512-1vvmgDdUSebVGXWX2lIcgRebqfQSff0hMEkLJyakQ9JQUbLDkEaMsPTLOmyccyC6IJ/l3FZuJbmrBw/u0A0uCQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.21.0':
     resolution: {integrity: sha512-s5oFkZ/hFcrlAyBTONFY1TWndfyre1wOMwU+6KCpm/iatybvrRgmZVM+vCFwxmC5ZhdlgfE0N4XorsDpi7/4XQ==}
@@ -422,6 +416,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.1':
     resolution: {integrity: sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==}
+
+  '@sugarat/theme-shared@0.0.4':
+    resolution: {integrity: sha512-pz58/c8hKTlKqi+pGZEmizGJ6GGPY/If/HKzOkLDg9WYPcBXQ8mP86aN/zIIqe+X0AXmmNOsiFswH7DDtu3Zsg==}
 
   '@types/animejs@3.1.12':
     resolution: {integrity: sha512-fpdH+ZtlO0kqjTOqRaBdsEmvpRNOayI8k4EVkEtitL5l6wducDOXk0rgQgfZqWf/ZX9DzXrHf257S5i9xTcISQ==}
@@ -621,6 +618,10 @@ packages:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
     engines: {node: '>=12.13'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
@@ -697,6 +698,10 @@ packages:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
 
+  feed@4.2.2:
+    resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
+    engines: {node: '>=0.4.0'}
+
   focus-trap@7.6.4:
     resolution: {integrity: sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==}
 
@@ -755,6 +760,9 @@ packages:
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
     engines: {node: '>=12.13'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -894,6 +902,10 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -950,6 +962,14 @@ packages:
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   shiki@2.3.0:
     resolution: {integrity: sha512-wMmrvyxj4i8ft9r2dA+aIi5+G6PL0Dz19h5fr5xG7Jvo8uLIOWxaveSRl3LNcj58h+jUnhdkCh7tQIVULGNXJw==}
@@ -1065,6 +1085,11 @@ packages:
       terser:
         optional: true
 
+  vitepress-plugin-rss@0.3.1:
+    resolution: {integrity: sha512-Q0tJ/j6D0c0WXG/VEF1FNyR8Kv72GPwytUipwKEx+3zL4/AllCgYkY/Hom38zY7t7bcDk5qXeudbhoIWT+1Q+A==}
+    peerDependencies:
+      vitepress: ^1
+
   vitepress@1.6.3:
     resolution: {integrity: sha512-fCkfdOk8yRZT8GD9BFqusW3+GggWYZ/rYncOfmgcDtP3ualNHCAg+Robxp2/6xfH1WwPHtGpPwv7mbA3qomtBw==}
     hasBin: true
@@ -1095,8 +1120,17 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   wicked-good-xpath@1.3.0:
     resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   xmldom-sre@0.1.31:
     resolution: {integrity: sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==}
@@ -1415,6 +1449,11 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.1': {}
 
+  '@sugarat/theme-shared@0.0.4':
+    dependencies:
+      cross-spawn: 7.0.6
+      gray-matter: 4.0.3
+
   '@types/animejs@3.1.12': {}
 
   '@types/estree@1.0.5': {}
@@ -1626,6 +1665,12 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   crypt@0.0.2: {}
 
   css-select@4.3.0:
@@ -1717,6 +1762,10 @@ snapshots:
     dependencies:
       is-extendable: 0.1.1
 
+  feed@4.2.2:
+    dependencies:
+      xml-js: 1.6.11
+
   focus-trap@7.6.4:
     dependencies:
       tabbable: 6.2.0
@@ -1789,6 +1838,8 @@ snapshots:
   is-what@3.14.1: {}
 
   is-what@4.1.16: {}
+
+  isexe@2.0.0: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -1947,6 +1998,8 @@ snapshots:
 
   parse5@6.0.1: {}
 
+  path-key@3.1.1: {}
+
   perfect-debounce@1.0.0: {}
 
   picocolors@1.1.1: {}
@@ -2004,8 +2057,7 @@ snapshots:
   safer-buffer@2.1.2:
     optional: true
 
-  sax@1.3.0:
-    optional: true
+  sax@1.3.0: {}
 
   search-insights@2.14.0: {}
 
@@ -2016,6 +2068,12 @@ snapshots:
 
   semver@5.7.2:
     optional: true
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   shiki@2.3.0:
     dependencies:
@@ -2115,6 +2173,12 @@ snapshots:
       fsevents: 2.3.3
       less: 4.2.2
 
+  vitepress-plugin-rss@0.3.1(vitepress@1.6.3(@algolia/client-search@5.14.2)(@types/node@22.13.1)(less@4.2.2)(markdown-it-mathjax3@4.3.2)(postcss@8.4.49)(search-insights@2.14.0)):
+    dependencies:
+      '@sugarat/theme-shared': 0.0.4
+      feed: 4.2.2
+      vitepress: 1.6.3(@algolia/client-search@5.14.2)(@types/node@22.13.1)(less@4.2.2)(markdown-it-mathjax3@4.3.2)(postcss@8.4.49)(search-insights@2.14.0)
+
   vitepress@1.6.3(@algolia/client-search@5.14.2)(@types/node@22.13.1)(less@4.2.2)(markdown-it-mathjax3@4.3.2)(postcss@8.4.49)(search-insights@2.14.0):
     dependencies:
       '@docsearch/css': 3.8.2
@@ -2191,7 +2255,15 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   wicked-good-xpath@1.3.0: {}
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.3.0
 
   xmldom-sre@0.1.31: {}
 


### PR DESCRIPTION
使用 [vitepress-plugin-rss](https://www.npmjs.com/package/vitepress-plugin-rss) 支持了 RSS 订阅，依赖于 `vitepress-plugin-rss`，build 后会在 dist 中生成 `feed.rss` 文件。

在实现过程中有几个问题：

1. `vitepress-plugin-rss` 由于实现了一个在社交媒体列表中加入 RSS 订阅图标的功能，依赖于 `themeConfig.socialLinks`，但是这个主题对应的 array 名称为 `soical`，会无法正常 build。我参考了 [VitePress 文档](https://vitepress.dev/reference/default-theme-config#sociallinks) 中社交媒体信息 array 的名称是 `socialLinks`，所以重构了所有 `social` -> `socialLinks`，可以正常生成 dist。

2. 由于渲染社交媒体图标依赖于 iconfont，~~加入 RSS 订阅图标功能没有正常实现~~，看了下似乎不好在不动插件源码的情况下修复，所以感觉直接在 `socialLinks` 中加入新的条目解决就好了。另外 iconfont 还没有 RSS 的图标，后续还需要添加。