### PR TITLE
调整gitalk评论区字体颜色以便于阅读

### DIFF
--- a/.vitepress/theme/components/Gitalk.vue
+++ b/.vitepress/theme/components/Gitalk.vue
@@ -34,9 +34,33 @@ onMounted(() => {
   
 }
 .gt-container .gt-comment-content{
-  background-color: var(--foreground-color) !important;
+  background-color: var(--gitalk-background) !important;
+  border-radius: 10px;
   p{
     color: var(--font-color-grey);
   }
+  ol{
+    color: var(--gitalk-font-color-ol);
+  }
+  .email-fragment {
+    color: var(--font-color-grey);
+  }
+  .email-hidden-reply {
+    color: var(--font-color-grey);
+  }
+}
+
+.gt-container .gt-comment-content:hover {
+  -webkit-box-shadow: var(--gitalk-shadow) !important;
+          box-shadow: var(--gitalk-shadow) !important; 
+}
+
+.gt-container .gt-comment-body {
+  color: #ffffff !important;
+}
+
+.markdown-body blockquote {
+  padding: 0 1em;
+  border-left: var(--gitalk-border-left) !important;
 }
 </style>

--- a/.vitepress/theme/styles/vars.less
+++ b/.vitepress/theme/styles/vars.less
@@ -46,6 +46,12 @@
   --search-list-bg: rgb(174, 193, 202);
   --search-item-bg: #fff;
   --search-item-shadow: rgba(69, 73, 78, 0.548);
+
+  // gitalk
+  --gitalk-shadow: 0 0 1em 0 #c6d8e7;
+  --gitalk-background: #f4f8ff;
+  --gitalk-border-left: 0.25em solid #dfe2e5;
+  --gitalk-font-color-ol: rgb(116, 125, 135);
 }
 
 html[theme='dark'] {
@@ -91,4 +97,10 @@ html[theme='dark'] {
   --search-list-bg: #2a2a3a;
   --search-item-bg: #1f1f2c;
   --search-item-shadow: rgba(0, 0, 0, 0.5);
+
+  // gitalk
+  --gitalk-shadow: 0 0 1em 0 #40335c;
+  --gitalk-background: #1a1a24;
+  --gitalk-border-left: 0.25em solid #514a6a;
+  --gitalk-font-color-ol: #7e7e8d;
 }


### PR DESCRIPTION
前
<img width="1597" height="1046" alt="image" src="https://github.com/user-attachments/assets/be05309b-6494-4b9b-9d33-05a94e7100b5" />
<img width="1550" height="1082" alt="image" src="https://github.com/user-attachments/assets/056aad0b-bfaf-42ff-a61a-af68c007758a" />
后
<img width="1547" height="1047" alt="image" src="https://github.com/user-attachments/assets/bc1b11c0-74a4-4d97-83cd-659feb83125c" />
<img width="1530" height="1047" alt="image" src="https://github.com/user-attachments/assets/bb818917-af1b-45d7-8177-a3fd6f3a87a3" />
